### PR TITLE
hotfix: 자료형 수정(int->long)

### DIFF
--- a/src/main/kotlin/com/wafflestudio/spring2025/course/dto/CourseSearchRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/course/dto/CourseSearchRequest.kt
@@ -6,6 +6,6 @@ data class CourseSearchRequest(
     val year: Int,
     val semester: Semester,
     val keyword: String?,
-    val nextId: Int?,
+    val nextId: Long?,
     val limit: Int = 20,
 )


### PR DESCRIPTION
courseSearchRequest의 nextId 자료형 Int?에서 Long?으로 수정