### PR TITLE
Swagger

### DIFF
--- a/src/main/kotlin/com/wafflestudio/spring2025/config/SwaggerConfig.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/config/SwaggerConfig.kt
@@ -17,9 +17,9 @@ class SwaggerConfig {
         return OpenAPI()
             .info(
                 Info()
-                    .title("Seminar 2025 Spring Boot API")
+                    .title("Wafflestudio 2025 Spring Boot Seminar Group9 Assignment2 API")
                     .version("1.0")
-                    .description("시간표 관리 API 문서"),
+                    .description("에브리타임 클론코딩 API 문서"),
             ).addSecurityItem(
                 SecurityRequirement().addList(securitySchemeName),
             ).components(
@@ -31,7 +31,7 @@ class SwaggerConfig {
                             .type(SecurityScheme.Type.HTTP)
                             .scheme("bearer")
                             .bearerFormat("JWT")
-                            .description("JWT 토큰을 입력하세요 (Bearer 제외)"),
+                            .description("JWT 토큰을 입력하세요"),
                     ),
             )
     }

--- a/src/main/kotlin/com/wafflestudio/spring2025/user/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/wafflestudio/spring2025/user/JwtAuthenticationFilter.kt
@@ -11,6 +11,8 @@ import org.springframework.web.filter.OncePerRequestFilter
 class JwtAuthenticationFilter(
     private val jwtTokenProvider: JwtTokenProvider,
 ) : OncePerRequestFilter() {
+    private val pathMatcher = AntPathMatcher()
+
     override fun doFilterInternal(
         request: HttpServletRequest,
         response: HttpServletResponse,
@@ -42,10 +44,8 @@ class JwtAuthenticationFilter(
         return null
     }
 
-    private fun isPublicPath(path: String): Boolean {
-        val pathMatcher = AntPathMatcher()
-        return pathMatcher.match("/api/v1/auth/**", path) ||
+    private fun isPublicPath(path: String): Boolean =
+        pathMatcher.match("/api/v1/auth/**", path) ||
             pathMatcher.match("/swagger-ui/**", path) ||
             pathMatcher.match("/v3/api-docs/**", path)
-    }
 }


### PR DESCRIPTION
Swagger를 사용할 수 있도록 Swagger config를 수정하였습니다.
또한, swagger 문서에는 public 하게 접근할 수 있도록 JWT authentication filter에서 swagger가 자유롭게 접근할 수 있도록 코드를 살짝 변경하였습니다.

다음과 같이 swagger를 이용한 test를 진행합니다.
1. docker compose down으로 현재 실행중인 서버를 중지합니다.
2. docker compose up -d를 실행합니다.
3. ./gradlew bootRun으로 서버를 실행합니다.
4. 브라우저에서 http://localhost:8080/swagger-ui/index.html 에 접속합니다.
5. Swagger 창이 뜨면 auth-controller에서 register를 하고 login을 합니다.
6. login 결과로 나온 JWT token을, 스크롤을 가장 위로 올린 상태에서 화면 오른쪽에 보이는 Authorize 버튼을 누르면 나오는 칸에 입력합니다.
7. 이제 로그인 되었으므로 회원가입과 로그인 이외의 모든 API 요청을 보내볼 수 있습니다. 강의 fetch를 해오는 데에 시간이 오래 걸리므로 이걸 먼저 돌려놓고 다른 것들을 해보도록 합시다.