### PR TITLE
hotfix: Datagenerator CourseGenerate에서 Random 사용 안하게 변경

### DIFF
--- a/src/test/kotlin/com/wafflestudio/spring2025/helper/DataGenerator.kt
+++ b/src/test/kotlin/com/wafflestudio/spring2025/helper/DataGenerator.kt
@@ -19,6 +19,7 @@ import com.wafflestudio.spring2025.user.model.User
 import com.wafflestudio.spring2025.user.repository.UserRepository
 import org.mindrot.jbcrypt.BCrypt
 import org.springframework.stereotype.Component
+import java.util.concurrent.atomic.AtomicLong
 import kotlin.random.Random
 
 @Component
@@ -108,6 +109,10 @@ class DataGenerator(
         return timetable
     }
 
+    companion object {
+        private val idCounter = AtomicLong(1L)
+    }
+
     fun generateCourse(
         year: Int? = null,
         semester: Semester? = null,
@@ -123,6 +128,7 @@ class DataGenerator(
         instructor: String? = null,
         classTimeJson: List<ClassPlaceAndTime>? = null,
     ): Course {
+        val nextId = idCounter.getAndIncrement()
         val course =
             courseRepository.save(
                 Course(
@@ -133,9 +139,9 @@ class DataGenerator(
                     department = department,
                     academicCourse = academicCourse,
                     academicYear = academicYear,
-                    courseNumber = courseNumber ?: "L0000-${Random.nextInt(10000)}",
+                    courseNumber = courseNumber ?: "L0000-$nextId",
                     lectureNumber = lectureNumber ?: "001",
-                    courseTitle = courseTitle ?: "강의-${Random.nextInt(1000000)}",
+                    courseTitle = courseTitle ?: "강의-$nextId",
                     credit = credit ?: 3L,
                     instructor = instructor,
                     classTimeJson = classTimeJson,


### PR DESCRIPTION
generateCourse에서 random 함수를 사용하는 것이 아니라 매 호출마다 값이 1씩 증가하는 변수를 만들어 사용하도록 변경하였습니다.

minor issue:
그런데 이 branch를 test하는 동안 course와 timetable 관련 test는 다 괜찮았는데 PostIntegrationTest에서 서로 다른 실패가 두 번 각각 발생했습니다. 자세한 내용은 issue 탭에 기록해 두었습니다. 